### PR TITLE
Rename ServerHost

### DIFF
--- a/ServerHost.nuspec
+++ b/ServerHost.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ServerHost</id>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
     <authors>Jorgen Thelin</authors>
     <owners>Jorgen Thelin</owners>
     <licenseUrl>https://github.com/jthelin/ServerHost/blob/master/LICENSE</licenseUrl>

--- a/ServerHost/ServerHost.cs
+++ b/ServerHost/ServerHost.cs
@@ -8,30 +8,35 @@ using System.IO;
 using System.Reflection;
 using log4net;
 
-namespace ServerHost
+namespace Server.Host
 {
     /// <summary>
     /// Data holder class for information related to a hosted in-process test server instance.
     /// </summary>
     /// <typeparam name="TServer">Type of the server.</typeparam>
     public class ServerHostHandle<TServer> 
-        where TServer : MarshalByRefObject
     {
+        internal ServerHostHandle()
+        {
+            // Prevent the arbitrary creation of ServerHostHandle objects.
+        }
+
         /// <summary> The name of this server. </summary>
         public string ServerName { get; internal set; }
-        /// <summary> Reference to the Server instance in the hoster AppDomain. </summary>
+        /// <summary> Reference to the Server instance in the hosted AppDomain. 
+        /// This should be a <c>MarshalByRefObject</c> to allow cross-domain API calls.</summary>
         public TServer Server { get; internal set; }
         /// <summary> Reference to the AppDomain this server is running in. </summary>
         public AppDomain AppDomain { get; internal set; }
     }
 
     /// <summary>
-    /// A test framework class for loading server instances into individual AppDomains in current process.
+    /// A hosting / test framework class for loading server instances into individual AppDomains in current process.
     /// </summary>
     /// <remarks>Uses <c>log4net</c> for logging. See: http://logging.apache.org/log4net/</remarks>
-    public static class ServerTestHost
+    public static class ServerHost
     {
-        private static readonly ILog log = LogManager.GetLogger("ServerTestHost");
+        private static readonly ILog log = LogManager.GetLogger("ServerHost");
 
         private static readonly List<AppDomain> loadedAppDomains = new List<AppDomain>();
 

--- a/ServerHost/ServerHost.csproj
+++ b/ServerHost/ServerHost.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{98D61E3E-76A7-4664-BAF7-FBBF41A798D9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ServerHost</RootNamespace>
+    <RootNamespace>Server.Host</RootNamespace>
     <AssemblyName>ServerHost</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ServerTestHost.cs" />
+    <Compile Include="ServerHost.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Tests/ServerHostTests.cs
+++ b/Tests/ServerHostTests.cs
@@ -7,13 +7,13 @@ using log4net.Config;
 using Xunit;
 using Xunit.Abstractions;
 
-using ServerHost;
+using Server.Host;
 
 namespace Tests
 {
-    public class ServerTestHostTests : IClassFixture<ServerTestHostFixture>, IDisposable
+    public class ServerHostTests : IClassFixture<ServerHostTestFixture>, IDisposable
     {
-        //private static readonly ILog log = LogManager.GetLogger(typeof(ServerTestHostTests));
+        //private static readonly ILog log = LogManager.GetLogger(typeof(ServerHostTests));
 
         private readonly ITestOutputHelper output;
 
@@ -23,7 +23,7 @@ namespace Tests
         {
             string serverName = "LoadServerInNewAppDomain"; // TestContext.TestName;
 
-            ServerHostHandle<TestServer.Server> serverHostHandle = ServerTestHost
+            ServerHostHandle<TestServer.Server> serverHostHandle = ServerHost
                 .LoadServerInNewAppDomain<TestServer.Server>(serverName);
 
             serverHostHandle.Should().NotBeNull("Null ServerHostHandle returned.");
@@ -36,7 +36,7 @@ namespace Tests
         #region Test Initialization / Cleanup methods
 
         // TestInitialize
-        public ServerTestHostTests(ITestOutputHelper output, ServerTestHostFixture fixture)
+        public ServerHostTests(ITestOutputHelper output, ServerHostTestFixture fixture)
         {
             this.output = output;
             output.WriteLine("TestInitialize");
@@ -52,28 +52,28 @@ namespace Tests
             output.WriteLine("TestCleanup");
 
             output.WriteLine("UnloadAllServers");
-            ServerTestHost.UnloadAllServers();
+            ServerHost.UnloadAllServers();
         }
         #endregion
     }
 
-    public class ServerTestHostFixture : IDisposable
+    public class ServerHostTestFixture : IDisposable
     {
-        internal static readonly ILog log = LogManager.GetLogger(typeof(ServerTestHostFixture));
+        internal static readonly ILog log = LogManager.GetLogger(typeof(ServerHostTestFixture));
 
         // ClassInitialize
-        public ServerTestHostFixture()
+        public ServerHostTestFixture()
         {
             // Set up the log4net configuration.
             BasicConfigurator.Configure();
 
-            log.Info("ServerTestHostFixture - Initialize");
+            log.Info("ServerHostTestFixture - Initialize");
         }
 
         // ClassCleanup
         public void Dispose()
         {
-            log.Info("ServerTestHostFixture - Dispose");
+            log.Info("ServerHostTestFixture - Dispose");
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ServerTestHostTests.cs" />
+    <Compile Include="ServerHostTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Rename ServerTestHost -> ServerHost

Rename to clarify that this is a general in-process hosting mechanism, not just for testing purposes.

- Rename class `ServerTestHost` -> `ServerHost`

- Rename namespace `ServerHost` -> `Server.Host`

- Restrict constructor visibility to internal for `ServerHostHandle` to prevent the arbitrary creation of handle objects.
