### PR TITLE
Prefer32Bit = false

### DIFF
--- a/ServerHost.nuspec
+++ b/ServerHost.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ServerHost</id>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <authors>Jorgen Thelin</authors>
     <owners>Jorgen Thelin</owners>
     <licenseUrl>https://github.com/jthelin/ServerHost/blob/master/LICENSE</licenseUrl>

--- a/ServerHost.xunit/Properties/AssemblyInfo.cs
+++ b/ServerHost.xunit/Properties/AssemblyInfo.cs
@@ -35,3 +35,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly:InternalsVisibleTo("ServerHost.Tests")]

--- a/ServerHost/ServerHost.csproj.DotSettings
+++ b/ServerHost/ServerHost.csproj.DotSettings
@@ -1,0 +1,9 @@
+﻿<wpf:ResourceDictionary 
+    xml:space="preserve" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+    xmlns:s="clr-namespace:System;assembly=mscorlib" 
+    xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" 
+    xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    >
+    <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
+</wpf:ResourceDictionary>

--- a/TestServer/TestServer.csproj
+++ b/TestServer/TestServer.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">


### PR DESCRIPTION
- Mark `TestServer.exe` as being Prefer32Bit = false
- Mark `InternalsVisibleTo` the tests project, to allow whitebox testing.
- Turn off ReSharper suggestions to use new C# v6 features - we are sticking to just C# v5 [.NET 4.5] functionality for the moment.

