### PR TITLE
DotNet-Standard - Part 1

### DIFF
--- a/ServerHost/ServerHost.cs
+++ b/ServerHost/ServerHost.cs
@@ -67,12 +67,22 @@ namespace Server.Host
                 BindingFlags.Default, null, args, CultureInfo.CurrentCulture,
                 noActivationAttributes);
 
+            TServer server = serverObj as TServer;
+
+            if (server == null)
+            {
+                throw new InvalidCastException(string.Format(
+                    "Cannot cast server object {0} from assembly {1} to type {2} from assembly {3}",
+                    serverObj.GetType(), serverObj.GetType().Assembly.CodeBase,
+                    serverType, serverType.Assembly.CodeBase));
+            }
+
             appDomain.UnhandledException += ReportUnobservedException;
 
             return new ServerHostHandle<TServer>
             {
                 ServerName = serverName,
-                Server = (TServer) serverObj,
+                Server = server,
                 AppDomain = appDomain,
             };
         }

--- a/ServerHost/ServerHost.cs
+++ b/ServerHost/ServerHost.cs
@@ -39,7 +39,7 @@ namespace Server.Host
                 throw new ArgumentNullException ("serverName", "Server name param cannot be blank.");
             }
             Type serverType = typeof(TServer);
-            string assemblyName = serverType.Assembly.GetName().Name;
+            string assemblyName = serverType.GetTypeInfo().Assembly.GetName().Name;
             string serverAssembly = assemblyName + ".exe";
             if (!File.Exists(serverAssembly))
             {
@@ -73,8 +73,8 @@ namespace Server.Host
             {
                 throw new InvalidCastException(string.Format(
                     "Cannot cast server object {0} from assembly {1} to type {2} from assembly {3}",
-                    serverObj.GetType(), serverObj.GetType().Assembly.CodeBase,
-                    serverType, serverType.Assembly.CodeBase));
+                    serverObj.GetType(), serverObj.GetType().GetTypeInfo().Assembly.CodeBase,
+                    serverType, serverType.GetTypeInfo().Assembly.CodeBase));
             }
 
             appDomain.UnhandledException += ReportUnobservedException;
@@ -140,7 +140,7 @@ namespace Server.Host
 
             return new AppDomainSetup
             {
-                ApplicationBase = Environment.CurrentDirectory,
+                ApplicationBase = Directory.GetCurrentDirectory(),
                 ConfigurationFile = currentAppDomain.SetupInformation.ConfigurationFile,
                 ShadowCopyFiles = currentAppDomain.SetupInformation.ShadowCopyFiles,
                 ShadowCopyDirectories = currentAppDomain.SetupInformation.ShadowCopyDirectories,

--- a/Tests/ServerHostTests.cs
+++ b/Tests/ServerHostTests.cs
@@ -2,6 +2,7 @@
 // Licensed under Apache 2.0 https://github.com/jthelin/ServerHost/blob/master/LICENSE
 
 using System;
+using System.IO;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -41,7 +42,7 @@ namespace Server.Host.Tests
 
             output.WriteLine("{0} Fixture = {1}", className, fixture);
 
-            output.WriteLine("{0} Current directory = {1}", className, Environment.CurrentDirectory);
+            output.WriteLine("{0} Current directory = {1}", className, Directory.GetCurrentDirectory());
         }
 
         // TestCleanup

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -31,11 +31,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.4.13.1\lib\net45\FluentAssertions.dll</HintPath>
+      <HintPath>..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.4.13.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <HintPath>..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net">
@@ -43,20 +43,24 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.core">
       <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.execution.desktop">
       <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.assert">
       <HintPath>..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ServerHostTests.cs" />
@@ -85,5 +89,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>
 

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.13.1" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.3" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
- Some minor code tweaks for improved .NET Standard platform compatibility.
- Extra diags for cast exceptions.
- Clean up some cruft and inconsistencies in `Tests.csproj` file.
- Update `FluentAssertions` pkg to latest version.

