### PR TITLE
Xunit 2.3

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit.runner.console" version="2.1.0" />
+  <package id="xunit.runner.console" version="2.3.0" />
 </packages>

--- a/Build.sh
+++ b/Build.sh
@@ -1,4 +1,3 @@
 #/usr/bin/bash
 
 msbuild ServerHost.sln
-

--- a/Test.cmd
+++ b/Test.cmd
@@ -29,8 +29,9 @@ SET VS_IDE_DIR=%VS120COMNTOOLS%..\IDE
 SET VSTEST_EXE_DIR=%VS_IDE_DIR%\CommonExtensions\Microsoft\TestWindow
 SET VSTEST_EXE=%VSTEST_EXE_DIR%\VSTest.console.exe
 
-set XUNIT_VER=2.1.0
-SET XUNIT_EXE_DIR=%CMDHOME%\packages\xunit.runner.console.%XUNIT_VER%\tools
+set XUNIT_VER=2.3.0
+set XUNIT_DOTNET_PLATFORM_VER=net452
+SET XUNIT_EXE_DIR=%CMDHOME%\packages\xunit.runner.console.%XUNIT_VER%\tools\%XUNIT_DOTNET_PLATFORM_VER%
 SET XUNIT_EXE=%XUNIT_EXE_DIR%\xunit.console.exe
 
 cd "%CMDHOME%"

--- a/Test.sh
+++ b/Test.sh
@@ -1,3 +1,3 @@
 #/usr/bin/bash
 
-mono packages/xunit.runner.console.2.1.0/tools/xunit.console.exe Tests/bin/Debug/ServerHost.Tests.dll
+mono packages/xunit.runner.console.2.3.0/tools/net452/xunit.console.exe Tests/bin/Debug/ServerHost.Tests.dll

--- a/Tests/App.config
+++ b/Tests/App.config
@@ -1,20 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
   </configSections>
   <log4net>
-    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender" >
+    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%-5level [%thread] %logger - %message%newline" />
+        <conversionPattern value="%-5level [%thread] %logger - %message%newline"/>
       </layout>
     </appender>
     <root>
-      <level value="INFO" />
-      <appender-ref ref="ConsoleAppender" />
+      <level value="INFO"/>
+      <appender-ref ref="ConsoleAppender"/>
     </root>
   </log4net>
   <appSettings>
     <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+  </startup>
 </configuration>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Server.Host.Tests</RootNamespace>
     <AssemblyName>ServerHost.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.msbuild.2.3.0\build\net452\xunit.runner.msbuild.props" />
+  <Import Project="..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.3.0\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.3.0\build\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -31,13 +34,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions.Core, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
@@ -46,21 +47,23 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\packages\xunit.assert.2.3.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop">
-      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\packages\xunit.extensibility.core.2.3.0\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\packages\xunit.extensibility.execution.2.3.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.runner.reporters.net452, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\packages\xunit.runner.reporters.2.3.0\lib\net452\xunit.runner.reporters.net452.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.runner.utility.net452, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\packages\xunit.runner.utility.2.3.0\lib\net452\xunit.runner.utility.net452.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -88,13 +91,20 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.3.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.3.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props'))" />
   </Target>
+  <Import Project="..\packages\xunit.core.2.3.0\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.3.0\build\xunit.core.targets')" />
+  <Import Project="..\packages\xunit.runner.msbuild.2.3.0\build\net452\xunit.runner.msbuild.targets" />
 </Project>
-

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,12 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.3" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+  <package id="xunit" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.3.0" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.runner.msbuild" version="2.3.0" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.runner.reporters" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.runner.utility" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.3.0" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Update package versions for xunit test framework `v2.3.0` + `FluentAssertions` `v4.19.4`.

Tests -> .NET 4.6.1 [.NET Standard 2.0 compatible]
