### PR TITLE
Fix Namespaces

### DIFF
--- a/ServerHost.nuspec
+++ b/ServerHost.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ServerHost</id>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <authors>Jorgen Thelin</authors>
     <owners>Jorgen Thelin</owners>
     <licenseUrl>https://github.com/jthelin/ServerHost/blob/master/LICENSE</licenseUrl>

--- a/ServerHost.xunit/ServerHost.xunit.csproj
+++ b/ServerHost.xunit/ServerHost.xunit.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{E4F2ED11-97D4-48A0-9616-55030599A272}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ServerHost.Test.Xunit</RootNamespace>
+    <RootNamespace>Server.Host.Test.Xunit</RootNamespace>
     <AssemblyName>ServerHost.xunit</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/ServerHost.xunit/ServerHostTestFixture.cs
+++ b/ServerHost.xunit/ServerHostTestFixture.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using log4net;
 using log4net.Config;
 
-namespace ServerHost.Test.Xunit
+namespace Server.Host.Test.Xunit
 {
     /// <summary>
     /// xUnit test fixture to provide per-test-class usage of hosted server instances.

--- a/ServerHost.xunit/ServerHostTestFixture.cs
+++ b/ServerHost.xunit/ServerHostTestFixture.cs
@@ -34,7 +34,6 @@ namespace Server.Host.Test.Xunit
         // Test-ClassCleanup
         public void Dispose()
         {
-            _log.InfoFormat("{0} - Dispose", _className);
             Dispose(true);
             GC.SuppressFinalize(this);
         }
@@ -44,6 +43,8 @@ namespace Server.Host.Test.Xunit
             ReleaseUnmanagedResources();
             if (disposing)
             {
+                _log.InfoFormat("{0} - Dispose", _className);
+
                 // TODO release managed resources here
             }
         }
@@ -56,6 +57,8 @@ namespace Server.Host.Test.Xunit
         [SuppressMessage("ReSharper", "MemberCanBeMadeStatic.Local")]
         private void ReleaseUnmanagedResources()
         {
+            _log.InfoFormat("{0} - ReleaseUnmanagedResources", _className);
+
             // TODO release unmanaged resources here
         }
     }

--- a/Tests/ServerHostTests.cs
+++ b/Tests/ServerHostTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using FluentAssertions;
-using ServerHost.Test.Xunit;
+using Server.Host.Test.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/ServerHostTests.cs
+++ b/Tests/ServerHostTests.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace Server.Host.Tests
 {
-    public class ServerHostTests : IClassFixture<ServerHostTestFixture>, IDisposable
+    public sealed class ServerHostTests : IClassFixture<ServerHostTestFixture>, IDisposable
     {
         private readonly ITestOutputHelper _output;
         private readonly string _className;


### PR DESCRIPTION
Avoid using `ServerHost` as a namespace [component] due to overlap & IntelliSense confusion with the `ServerHost` class.