### PR TITLE
Initial default for GitVersion.yml baseline config.

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,3 @@
+next-version: 1.1.7
+assembly-versioning-scheme: Major
+mode: ContinuousDelivery


### PR DESCRIPTION
- Initial default for `GitVersion.yml` config file for `master` branch, to unblock CI builds for PR and branches.