### PR TITLE
Assembly version tests

### DIFF
--- a/ServerHost/LibraryVersionInfo.cs
+++ b/ServerHost/LibraryVersionInfo.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Jorgen Thelin. All rights reserved.
+// Licensed with Apache 2.0 https://github.com/jthelin/ServerHost/blob/master/LICENSE
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Server.Host
+{
+    /// <summary>
+    /// Version info for ServerHost library.
+    /// </summary>
+    /// <remarks>
+    /// Based on the <c>Orleans.Runtime.RuntimeVersion</c> class.
+    /// https://github.com/dotnet/orleans/blob/master/src/Orleans/Runtime/RuntimeVersion.cs
+    /// </remarks>
+    public static class LibraryVersionInfo
+    {
+        private static readonly TypeInfo libraryTypeInfo = typeof(ServerHost).GetTypeInfo();
+
+        /// <summary>
+        /// The full version string of the library.
+        /// eg: '2012.5.9.51607 Build:12345 Timestamp: 20120509-185359'
+        /// </summary>
+        public static string Current
+        {
+            get
+            {
+                Assembly me = libraryTypeInfo.Assembly;
+                FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(me.Location);
+                // NOTE: progVersionInfo.IsDebug; does not work here.
+                bool isDebug = IsAssemblyDebugBuild(me);
+                string productVersion = versionInfo.ProductVersion + (isDebug ? " (Debug)" : " (Release)");
+                return string.IsNullOrEmpty(productVersion) ? ApiVersion : productVersion;
+            }
+        }
+
+        /// <summary>
+        /// The ApiVersion of the library.
+        /// eg: '1.0.0.0'
+        /// </summary>
+        public static string ApiVersion
+        {
+            get
+            {
+                Assembly me = libraryTypeInfo.Assembly;
+                AssemblyName libraryInfo = me.GetName();
+                return libraryInfo.Version.ToString();
+            }
+        }
+
+        /// <summary>
+        /// The FileVersion of the library.
+        /// eg: '2012.5.9.51607'
+        /// </summary>
+        public static string FileVersion
+        {
+            get
+            {
+                Assembly me = libraryTypeInfo.Assembly;
+                FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(me.Location);
+                string fileVersion = versionInfo.FileVersion;
+                return string.IsNullOrEmpty(fileVersion) ? ApiVersion : fileVersion;
+            }
+        }
+
+        private static bool IsAssemblyDebugBuild(Assembly assembly)
+        {
+            foreach (object attribute in assembly.GetCustomAttributes(false))
+            {
+                DebuggableAttribute debuggableAttribute = attribute as DebuggableAttribute;
+                if (debuggableAttribute != null)
+                {
+                    return debuggableAttribute.IsJITTrackingEnabled;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/ServerHost/Properties/AssemblyInfo.cs
+++ b/ServerHost/Properties/AssemblyInfo.cs
@@ -1,21 +1,19 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("ServerHost")]
+// General Information about an assembly is controlled through the following set of attributes.
+// Change these attribute values to modify the information associated with an assembly.
+[assembly: AssemblyTitle("ServerHost.Library")]
 [assembly: AssemblyDescription("ServerHost - A .NET Server Hosting utility library, including in-process server host testing.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Jorgen Thelin")]
 [assembly: AssemblyProduct("ServerHost")]
-[assembly: AssemblyCopyright("Copyright © Jorgen Thelin 2015-2017")]
+[assembly: AssemblyCopyright("Copyright © Jorgen Thelin 2015-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
+// Setting ComVisible to false makes the types in this assembly not visible to COM components.
+// If you need to access a type in this assembly from COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
@@ -24,12 +22,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
+// You can specify all the values or you can default the Build and Revision Numbers by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: AssemblyVersion("1.1.7.*")]
+// [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ServerHost/ServerHost.cs
+++ b/ServerHost/ServerHost.cs
@@ -32,7 +32,7 @@ namespace Server.Host
         /// Multiple copies of a server can be created if they arer each given a different server name.
         /// </remarks>
         public static ServerHostHandle<TServer> LoadServerInNewAppDomain<TServer>(
-            string serverName) 
+            string serverName)
             where TServer : MarshalByRefObject
         {
             if (string.IsNullOrEmpty(serverName)) {
@@ -58,7 +58,7 @@ namespace Server.Host
             AppDomain appDomain = AppDomain.CreateDomain(serverName, null, setup);
             LoadedAppDomains.Add(appDomain);
 
-            // The server class must have a public constructor which 
+            // The server class must have a public constructor which
             // accepts single parameter of server name.
             var args = new object[] { serverName };
             var noActivationAttributes = new object[0];
@@ -93,14 +93,14 @@ namespace Server.Host
         /// </summary>
         /// <param name="appDomain">The AppDomain to be unloaded.</param>
         /// <remarks>
-        /// No specific checks are done to confirm that the specified 
+        /// No specific checks are done to confirm that the specified
         /// AppDomain was created by this class and/or contains a hosted server.
         /// </remarks>
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         public static void UnloadServerInAppDomain(AppDomain appDomain)
         {
             if (appDomain == null) return;
-            
+
             try
             {
                 LoadedAppDomains.Remove(appDomain);
@@ -123,7 +123,7 @@ namespace Server.Host
             foreach (AppDomain appDomain in LoadedAppDomains.ToArray()) // Take working copy
             {
                 if (appDomain == null) continue;
-                
+
                 Log.InfoFormat("Unloading AppDomain {0}", appDomain.FriendlyName);
                 UnloadServerInAppDomain(appDomain);
             }
@@ -152,7 +152,7 @@ namespace Server.Host
         /// Event handle method to report any unhandled exceptions in a newly created AppDomain.
         /// </summary>
         /// <remarks>
-        /// This event handler is automatically 
+        /// This event handler is automatically
         /// hooked up when AppDomain was created in <c>LoadServerInNewAppDomain</c>,
         /// and unhooked when AppDomain is unloaded in <c>UnloadServerInAppDomain</c>.
         /// </remarks>

--- a/ServerHost/ServerHost.csproj
+++ b/ServerHost/ServerHost.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -44,6 +44,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LibraryVersionInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerHost.cs" />
     <Compile Include="ServerHostHandle.cs" />

--- a/ServerHost/ServerHostFixture.cs
+++ b/ServerHost/ServerHostFixture.cs
@@ -64,7 +64,7 @@ namespace Server.Host
         {
             Dispose(false);
         }
-        
+
         [SuppressMessage("ReSharper", "MemberCanBeMadeStatic.Local")]
         private void ReleaseUnmanagedResources()
         {

--- a/ServerHost/ServerHostHandle.cs
+++ b/ServerHost/ServerHostHandle.cs
@@ -9,7 +9,7 @@ namespace Server.Host
     /// Data holder class for information related to a hosted in-process test server instance.
     /// </summary>
     /// <typeparam name="TServer">Type of the server.</typeparam>
-    public class ServerHostHandle<TServer> 
+    public class ServerHostHandle<TServer>
     {
         internal ServerHostHandle()
         {
@@ -18,7 +18,7 @@ namespace Server.Host
 
         /// <summary> The name of this server. </summary>
         public string ServerName { get; internal set; }
-        /// <summary> Reference to the Server instance in the hosted AppDomain. 
+        /// <summary> Reference to the Server instance in the hosted AppDomain.
         /// This should be a <c>MarshalByRefObject</c> to allow cross-domain API calls.</summary>
         public TServer Server { get; internal set; }
         /// <summary> Reference to the AppDomain this server is running in. </summary>

--- a/Tests/Tests.Net46/App.config
+++ b/Tests/Tests.Net46/App.config
@@ -24,11 +24,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.3820" newVersion="2.3.0.3820" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.3820" newVersion="2.3.0.3820" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Tests/Tests.Net46/App.config
+++ b/Tests/Tests.Net46/App.config
@@ -1,23 +1,35 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <log4net>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%-5level [%thread] %logger - %message%newline"/>
+        <conversionPattern value="%-5level [%thread] %logger - %message%newline" />
       </layout>
     </appender>
     <root>
-      <level value="INFO"/>
-      <appender-ref ref="ConsoleAppender"/>
+      <level value="INFO" />
+      <appender-ref ref="ConsoleAppender" />
     </root>
   </log4net>
   <appSettings>
-    <add key="xunit.shadowCopy" value="false"/>
+    <add key="xunit.shadowCopy" value="false" />
   </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.3820" newVersion="2.3.0.3820" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.3820" newVersion="2.3.0.3820" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Tests/Tests.Net46/Properties/AssemblyInfo.cs
+++ b/Tests/Tests.Net46/Properties/AssemblyInfo.cs
@@ -1,21 +1,19 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Tests")]
+// General Information about an assembly is controlled through the following set of attributes.
+// Change these attribute values to modify the information associated with an assembly.
+[assembly: AssemblyTitle("ServerHost.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Jorgen Thelin")]
-[assembly: AssemblyProduct("Tests")]
-[assembly: AssemblyCopyright("Copyright © Jorgen Thelin 2015-2017")]
+[assembly: AssemblyProduct("ServerHost")]
+[assembly: AssemblyCopyright("Copyright © Jorgen Thelin 2015-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
+// Setting ComVisible to false makes the types in this assembly not visible to COM components.  
+// If you need to access a type in this assembly from COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
@@ -24,12 +22,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
+// You can specify all the values or you can default the Build and Revision Numbers by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Tests.Net46/ServerHostTests.cs
+++ b/Tests/Tests.Net46/ServerHostTests.cs
@@ -43,7 +43,7 @@ namespace Server.Host.Tests.Net46
         {
             string testName = "LoadServerInNewAppDomain"; // TestContext.TestName;
 
-            ServerHostHandle<TestServer.Server> serverHostHandle = 
+            ServerHostHandle<TestServer.Server> serverHostHandle =
                 ServerHost.LoadServerInNewAppDomain<TestServer.Server>(testName);
 
             serverHostHandle.Should().NotBeNull("Null ServerHostHandle returned.");
@@ -51,6 +51,25 @@ namespace Server.Host.Tests.Net46
             serverHostHandle.AppDomain.Should().NotBeNull("Null ServerHostHandle.AppDomain returned.");
             serverHostHandle.Server.Should().NotBeNull("Null ServerHostHandle.Server returned.");
             serverHostHandle.Server.Should().BeOfType<TestServer.Server>("Server instance type.");
+        }
+
+        [Fact]
+        [Trait("Category", "BVT")]
+        public void ServerHost_Version()
+        {
+            _output.WriteLine("ServerHost library API version = {0}", LibraryVersionInfo.ApiVersion);
+            _output.WriteLine("ServerHost library file version = {0}", LibraryVersionInfo.FileVersion);
+            _output.WriteLine("ServerHost library full version info string = {0}", LibraryVersionInfo.Current);
+
+            string versionString = LibraryVersionInfo.FileVersion;
+            _output.WriteLine("ServerHost library version = {0}", versionString);
+
+            versionString.Should().NotBeNullOrEmpty("Version value should be returned");
+
+            versionString.Should().Contain(".", "Version format = Major.Minor");
+            versionString.Should().NotStartWith("1.0.0.0", "Version should be specific.");
+            versionString.Should().NotStartWith("0.0.0.0", "Version should not be zero.");
+            versionString.Should().NotContain("*", "Version should be explicit.");
         }
     }
 }

--- a/Tests/Tests.Net46/Tests.Net46.csproj
+++ b/Tests/Tests.Net46/Tests.Net46.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
@@ -64,6 +67,9 @@
     </Reference>
     <Reference Include="xunit.runner.utility.net452, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\..\packages\xunit.runner.utility.2.3.0\lib\net452\xunit.runner.utility.net452.dll</HintPath>
+    </Reference>
+    <Reference Include="Xunit.SkippableFact, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b2b52da82b58eb73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xunit.SkippableFact.1.3.3\lib\net452\Xunit.SkippableFact.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Tests.Net46/Tests.Net46.csproj
+++ b/Tests/Tests.Net46/Tests.Net46.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="..\..\packages\xunit.runner.msbuild.2.3.0\build\net452\xunit.runner.msbuild.props" />
   <Import Project="..\..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props" Condition="Exists('..\..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props')" />
   <Import Project="..\..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.3.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.0\build\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.1.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.5.1.2\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="log4net">
       <HintPath>..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
@@ -53,14 +53,14 @@
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.assert.2.3.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.3.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.runner.reporters.net452, Version=2.3.0.3820, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\..\packages\xunit.runner.reporters.2.3.0\lib\net452\xunit.runner.reporters.net452.dll</HintPath>
@@ -94,19 +94,18 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.0\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.0\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.console.2.3.0\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.3.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.0\build\xunit.core.targets')" />
   <Import Project="..\..\packages\xunit.runner.msbuild.2.3.0\build\net452\xunit.runner.msbuild.targets" />
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
 </Project>

--- a/Tests/Tests.Net46/packages.config
+++ b/Tests/Tests.Net46/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="Validation" version="2.4.18" targetFramework="net461" />
   <package id="xunit" version="2.3.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
@@ -14,4 +15,5 @@
   <package id="xunit.runner.reporters" version="2.3.0" targetFramework="net461" />
   <package id="xunit.runner.utility" version="2.3.0" targetFramework="net461" />
   <package id="xunit.runner.visualstudio" version="2.3.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Xunit.SkippableFact" version="1.3.3" targetFramework="net461" />
 </packages>

--- a/Tests/Tests.Net46/packages.config
+++ b/Tests/Tests.Net46/packages.config
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
+  <package id="FluentAssertions" version="5.1.2" targetFramework="net461" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="Validation" version="2.4.18" targetFramework="net461" />
-  <package id="xunit" version="2.3.0" targetFramework="net461" />
+  <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
-  <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
-  <package id="xunit.assert" version="2.3.0" targetFramework="net461" />
-  <package id="xunit.core" version="2.3.0" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.3.0" targetFramework="net461" />
+  <package id="xunit.analyzers" version="0.8.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net461" />
   <package id="xunit.runner.console" version="2.3.0" targetFramework="net461" developmentDependency="true" />
   <package id="xunit.runner.msbuild" version="2.3.0" targetFramework="net461" developmentDependency="true" />
   <package id="xunit.runner.reporters" version="2.3.0" targetFramework="net461" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ nuget:
   disable_publish_on_pr: true
 build_script:
 - cmd: Build.cmd
+test_script:
+- cmd: Test.cmd
 artifacts:
 - path: ServerHost\bin\Release\ServerHost.*
   name: ServerHost.dll


### PR DESCRIPTION
LibraryVersionInfo and AssemblyVersion

- Add LibraryVersionInfo class and simple test case.

- Set `AssemblyVersion` to auto-generated value.

- Import `[SkippableFact]` library for dynamic runtime skipping of test cases (eg "Inconclusive")
  https://github.com/AArnott/Xunit.SkippableFact

- Minor code cleanup (whitespace), from ReSharper.

- Extend copyright date to 2018.

- Update FluentAssertions package to latest v5.1.2.

- Update Xunit.Core package to latest v2.3.1.

- Run Tests.cmd script for Appveyor build.
