### PR TITLE
Harden code against race condition(s) during ServerHost.UnloadAllServer calls.

### DIFF
--- a/ServerHost/ServerHost.csproj.DotSettings
+++ b/ServerHost/ServerHost.csproj.DotSettings
@@ -1,9 +1,0 @@
-﻿<wpf:ResourceDictionary 
-    xml:space="preserve" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-    xmlns:s="clr-namespace:System;assembly=mscorlib" 
-    xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" 
-    xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    >
-    <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
-</wpf:ResourceDictionary>

--- a/Tests/Tests.Net46/ServerHostTests.cs
+++ b/Tests/Tests.Net46/ServerHostTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -51,6 +53,25 @@ namespace Server.Host.Tests.Net46
             serverHostHandle.AppDomain.Should().NotBeNull("Null ServerHostHandle.AppDomain returned.");
             serverHostHandle.Server.Should().NotBeNull("Null ServerHostHandle.Server returned.");
             serverHostHandle.Server.Should().BeOfType<TestServer.Server>("Server instance type.");
+        }
+
+        [Fact]
+        [Trait("Category", "BVT")]
+        public async Task UnloadServerInAppDomain()
+        {
+            ServerHost.LoadServerInNewAppDomain<TestServer.Server>("One");
+            ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Two");
+            ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Three");
+
+            var unload = Enumerable.Range(1, 4).Select(i =>
+            {
+                return Task.Run(async () =>
+                {
+                    await Task.Delay(100 - i);
+                    ServerHost.UnloadAllServers();
+                });
+            });
+            await Task.WhenAll(unload);
         }
 
         [Fact]


### PR DESCRIPTION
Harden code against race condition(s) during `ServerHost.UnloadAllServer()` calls.

Failure mode:
```
INFO  ServerHost [(null)] - Unloading AppDomain QueryDistributor_1
WARN  ServerHost [(null)] - Ignoring error unloading AppDomain QueryDistributor_1
- System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
    Parameter name: index
       at System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
       at System.Collections.Generic.List`1.RemoveAt(Int32 index)
       at System.Collections.Generic.List`1.Remove(T item)
       at Server.Host.ServerHost.UnloadServerInAppDomain(AppDomain appDomain)
```

Fixes #35