### PR TITLE
AppDomainUnloadedException thrown from UnloadAllServers function.

### DIFF
--- a/ServerHost/ServerHost.csproj
+++ b/ServerHost/ServerHost.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.11</Version>
+    <Version>1.1.12</Version>
     <Authors>Jorgen Thelin</Authors>
     <Copyright>Copyright © Jorgen Thelin 2015-2018</Copyright>
     <Description>ServerHost - A .NET Server Hosting utility library, including in-process server host testing.</Description>
@@ -23,13 +23,13 @@
     <RepositoryUrl>https://github.com/jthelin/ServerHost.git</RepositoryUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TRAVIS)' == 'true'" >
+  <PropertyGroup Condition="'$(TRAVIS)' == 'true'">
     <!-- Disable SourceLink when running Travis-CI build, due to bug. -->
     <!-- https://github.com/dotnet/sourcelink/issues/119 -->
     <EnableSourceLink>false</EnableSourceLink>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TRAVIS)' != 'true'" >
+  <PropertyGroup Condition="'$(TRAVIS)' != 'true'">
 
     <!-- SourceLink settings: https://github.com/dotnet/sourcelink#using-sourcelink -->
 

--- a/Tests/Tests.Net46/ServerHostTests.cs
+++ b/Tests/Tests.Net46/ServerHostTests.cs
@@ -63,15 +63,28 @@ namespace Server.Host.Tests.Net46
             ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Two");
             ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Three");
 
-            var unload = Enumerable.Range(1, 4).Select(i =>
+            var unload = Enumerable.Range(1, 10).Select(i =>
             {
                 return Task.Run(async () =>
                 {
-                    await Task.Delay(100 - i);
+                    await Task.Delay(10 - i);
                     ServerHost.UnloadAllServers();
                 });
             });
             await Task.WhenAll(unload);
+        }
+
+        [Fact]
+        [Trait("Category", "BVT")]
+        public void UnloadAllAppDomainsTwice()
+        {
+            ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Four");
+            ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Five");
+            ServerHost.LoadServerInNewAppDomain<TestServer.Server>("Six");
+
+            ServerHost.UnloadAllServers();
+
+            ServerHost.UnloadAllServers();
         }
 
         [Fact]


### PR DESCRIPTION
Harden code against `System.AppDomainUnloadedException` - "Attempted to access an unloaded AppDomain".

`AppDomainUnloadedException` thrown from `Server.Host.ServerHost.UnloadAllServers()` if an AppDomain has already been unloaded / disposed.

Failure mode:
```
TestCleanup method Tests.ClusterTests.TestCleanup threw exception. System.AppDomainUnloadedException:
System.AppDomainUnloadedException: Attempted to access an unloaded AppDomain..
   at System.AppDomain.get_FriendlyName()
   at Server.Host.ServerHost.UnloadAllServers() in C:\projects\serverhost\ServerHost\ServerHost.cs:line 132
   at Tests.ClusterTests.TestCleanup() in E:\Depot\Internal\DSoAP\Testing\DSoAP.Tests\ClusterTests.cs:line 56
```

Fixes bug #46

Bump package version to `1.1.12`