### PR TITLE
Roll back the version of mono build used from latest (5.16) to 5.14.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 
 language: csharp
 mono:
-  - latest
+  - 5.14.0
 
 solution: ServerHost.sln
 script:


### PR DESCRIPTION
Roll back the version of mono build used from latest (5.16) to 5.14.

Fixes #48
