### PR TITLE
Reset target framework for Tests.Net46 project to 4.6.1

### DIFF
--- a/Test.cmd
+++ b/Test.cmd
@@ -30,7 +30,7 @@ SET VSTEST_EXE_DIR=%VS_IDE_DIR%\CommonExtensions\Microsoft\TestWindow
 SET VSTEST_EXE=%VSTEST_EXE_DIR%\VSTest.console.exe
 
 set XUNIT_VER=2.4.0
-set XUNIT_DOTNET_PLATFORM_VER=net462
+set XUNIT_DOTNET_PLATFORM_VER=net461
 SET XUNIT_EXE_DIR=%CMDHOME%\packages\xunit.runner.console.%XUNIT_VER%\tools\%XUNIT_DOTNET_PLATFORM_VER%
 SET XUNIT_EXE=%XUNIT_EXE_DIR%\xunit.console.exe
 

--- a/Test.sh
+++ b/Test.sh
@@ -1,3 +1,3 @@
 #/usr/bin/bash
 
-mono packages/xunit.runner.console.*/tools/net462/xunit.console.exe Tests/Tests.Net46/bin/Debug/ServerHost.Tests.dll
+mono packages/xunit.runner.console.*/tools/net461/xunit.console.exe Tests/Tests.Net46/bin/Debug/ServerHost.Tests.dll

--- a/Tests/Tests.Net46/Tests.Net46.csproj
+++ b/Tests/Tests.Net46/Tests.Net46.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RootNamespace>Server.Host.Tests.Net46</RootNamespace>
     <AssemblyName>ServerHost.Tests</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Reset target framework for Tests.Net46 project to 4.6.1

- `net461` is more widely available than `net462`.

- It seems .NET v4.6.2 does not get installed on all platforms, eg Win7.
