### PR TITLE
Force nuget regen to remove build-time dependencies.

### DIFF
--- a/ServerHost/ServerHost.csproj
+++ b/ServerHost/ServerHost.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.15</Version>
+    <Version>1.1.16</Version>
     <Authors>Jorgen Thelin</Authors>
     <Copyright>Copyright © Jorgen Thelin 2015-2018</Copyright>
     <Description>ServerHost - A .NET Server Hosting utility library, including in-process server host testing.</Description>
@@ -53,7 +53,6 @@
 
   <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Bump pkg version to 1.1.16 to force nuget regen to remove build-time dependencies.