### PR TITLE
Fully disable SourceLink if not building on Windows (esp MacOS).

### DIFF
--- a/ServerHost/ServerHost.csproj
+++ b/ServerHost/ServerHost.csproj
@@ -26,14 +26,14 @@
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TRAVIS)' == 'true'">
+  <PropertyGroup Condition="'$(TRAVIS)' == 'true' OR '$(OS)' != 'Windows_NT'">
     <!-- Disable SourceLink when running Travis-CI build, due to bug. -->
     <!-- https://github.com/dotnet/sourcelink/issues/119 -->
     <EnableSourceLink>false</EnableSourceLink>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TRAVIS)' != 'true'">
-
+  <PropertyGroup>
     <!-- SourceLink settings: https://github.com/dotnet/sourcelink#using-sourcelink -->
 
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/Tests/Tests.Net46/Tests.Net46.csproj
+++ b/Tests/Tests.Net46/Tests.Net46.csproj
@@ -16,7 +16,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.5.1" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Validation" Version="2.4.18" />


### PR DESCRIPTION
Fully disable SourceLink if not building on Windows (especially MacOS).

EnableSourceControlManagerQueries = false

X-ref:
https://github.com/dotnet/sourcelink/issues/204
https://github.com/dotnet/core-sdk/commit/fe80bc7ba35b2b569b05741882dea7e16592abeb#diff-4b2f402501d23abbede6eac0f47783e4R19