### PR TITLE
Remove waffle.io work item dashboard links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,3 @@
 Mono | Windows
 ---- | -------
 [![Build Status](https://travis-ci.org/jthelin/ServerHost.svg?branch=master)](https://travis-ci.org/jthelin/ServerHost) | [![Build status](https://ci.appveyor.com/api/projects/status/2y41gnrcl5nqldw6/branch/master?svg=true)](https://ci.appveyor.com/project/jthelin/serverhost/branch/master)
-
-## Work Item Dashboard
-
-[![Backlog Work Items](https://badge.waffle.io/jthelin/ServerHost.png?label=backlog&title=Backlog)](https://waffle.io/jthelin/ServerHost)
-[![Ready Work Items](https://badge.waffle.io/jthelin/ServerHost.png?label=ready&title=Ready)](https://waffle.io/jthelin/ServerHost)
-[![In-Progress Work Items](https://badge.waffle.io/jthelin/ServerHost.png?label=in%20progress&title=In%20Progress)](https://waffle.io/jthelin/ServerHost)


### PR DESCRIPTION
The waffle.io work item dashboard service has shut down and is no longer available after 16-May-2019.

https://web.archive.org/web/20190317040044/https://waffle.io/closing-its-doors

https://news.ycombinator.com/item?id=19400833

https://www.bluehousegroup.com/blog/waffleio-alternative/

Fixes issue #78