### PR TITLE
[LGTM] Fix cs/useless-assignment-to-local

### DIFF
--- a/ServerHost/ServerHost.cs
+++ b/ServerHost/ServerHost.cs
@@ -168,10 +168,10 @@ namespace Server.Host
         {
             try
             {
-                string unused = appDomain.FriendlyName;
+                string name = appDomain.FriendlyName;
 
-                // If this worked, then the AppDomain is still accessible.
-                return false;
+                // If this worked (no exception thrown), then the AppDomain is still accessible.
+                return String.IsNullOrEmpty(name);
             }
             catch (AppDomainUnloadedException)
             {


### PR DESCRIPTION
LGTM code analysis reported the following issue:

This assignment to unused is useless, since its value is never read.

An assignment to a local variable that is not used later on, or whose value is always overwritten, has no effect.

https://lgtm.com/rules/1506093386171/

https://lgtm.com/projects/g/jthelin/ServerHost/snapshot/d7c80fd48f0dcabb221cd84f92c7b16d46e028da/files/ServerHost/ServerHost.cs?sort=name&dir=ASC&mode=heatmap#xbbc6213c3d4c8f26:1

Fixes issue #81